### PR TITLE
Integrate 'keyring' encryption type

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,7 @@ Linux
 
 .. code-block:: bash
 
-    $ pip install -r requirements.txt
+    $ pip install -r requirements-linux.txt
 
 Run the app
 ===========

--- a/requirements-linux.txt
+++ b/requirements-linux.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+secretstorage
+dbus-python

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+keyring
 docopt
 paramiko>=2.0.0
 cryptography

--- a/src/cli/screen.py
+++ b/src/cli/screen.py
@@ -10,23 +10,69 @@ Options:
   --storage=<provider>  Overwrite the storage config parameter
 """
 import os
+import logging
+import keyring
+import getpass
 
 from docopt import docopt
 from tools.config import CONFIG
+from tools.encryption import CryptoError
+from tools.persistence import KVStore, PersistentDataEncryptedError
 from importlib import import_module
 from tempfile import gettempdir
 from time import strftime
-import logging
+
+
+def _load_persistent_data(module: str):
+    encryption = CONFIG.get(CONFIG.general, "encryption")
+    if encryption == "password":
+        pass
+
+    elif encryption == "keyring":
+        # retrieve password from keyring or create one
+        user = getpass.getuser()
+        pw = keyring.get_password("instantshare", user)
+        if pw is None:
+            pw = getpass.getpass("Please enter your encryption password:")
+            keyring.set_password("instantshare", user, pw)
+
+        while True:
+            try:
+                return KVStore(module, pw)
+            except CryptoError:
+                pw = getpass.getpass("[Decryption Failure] Enter password:")
+
+    else:
+        try:
+            return KVStore(module)
+        except PersistentDataEncryptedError:
+            pw = getpass.getpass("Previous encryption password (one last time):")
+
+            while True:
+                try:
+                    kvs = KVStore(module, pw, unlock=True)
+                    try:  # if the above succeeded, try to remove password from keyring
+                        user = getpass.getuser()
+                        keyring.delete_password("instantshare", user)
+                    except:
+                        # keyring backend spec does not include exception type
+                        pass  # password did not exist, so we don't need to remove it
+                    return kvs
+                except CryptoError:
+                    pw = getpass.getpass("[Decryption Failure] Enter password:")
 
 
 def main(argv):
     args = docopt(__doc__, argv=argv)
 
     # import modules dynamically
-    scrtool = args["--tool"] if args["--tool"] else CONFIG.get(CONFIG.general, "screenshot_tool")
-    storage = args["--storage"] if args["--storage"] else CONFIG.get(CONFIG.general, "storage")
-    scrtool = import_module("screenshot." + scrtool)
-    storage = import_module("storage." + storage)
+    scrtool_str = args["--tool"] if args["--tool"] else CONFIG.get(CONFIG.general, "screenshot_tool")
+    storage_str = args["--storage"] if args["--storage"] else CONFIG.get(CONFIG.general, "storage")
+    scrtool = import_module("screenshot." + scrtool_str)
+    storage = import_module("storage." + storage_str)
+
+    # get persistent data for storage provider
+    storage.kvstore = _load_persistent_data(storage_str)
 
     # build filename
     file = "{}/instantscreen_{}.png".format(gettempdir(), strftime("%Y-%m-%d_%H-%I-%S"))

--- a/src/res/instantshare.default
+++ b/src/res/instantshare.default
@@ -1,5 +1,17 @@
 [General]
 
+# How (or if at all) to encrypt data that is used to access your storage provider.
+# This includes:
+#   - access tokens (allow usage the service in question in your name)
+#   - credentials (username and password)
+#   - passphrases for key files
+#
+# Possible values:
+#   - None (or leave it empty): No encryption will be used
+#   - password: you will be asked to enter a password everytime you use instantshare
+#   - keyring: create a password and store it in the system keyring
+encryption =
+
 # The hoster you want to upload your screenshots to.
 # Possible Values: imgur, dropbox, googledrive, sftp
 storage = imgur

--- a/src/storage/dropbox.py
+++ b/src/storage/dropbox.py
@@ -6,11 +6,10 @@ from dropbox.files import WriteMode
 
 from tools.config import CONFIG
 from tools.oauthtool import implicit_flow
-from tools.persistence import KVStore
+from tools.persistence import KVStub
 
 _name = "dropbox"
-# TODO: encryption
-kvstore = KVStore(_name)
+kvstore = KVStub()
 
 
 def upload(file: str) -> str:

--- a/src/storage/googledrive.py
+++ b/src/storage/googledrive.py
@@ -11,15 +11,15 @@ from oauth2client import client
 from oauth2client import tools
 import logging
 from tools.config import CONFIG
-from tools.persistence import KVStore
+from tools.persistence import KVStub
 
 SCOPES = 'https://www.googleapis.com/auth/drive'
 CLIENT_SECRET_FILE = 'client_secret.json'
 APPLICATION_NAME = 'Instantshare'
-
 _name = "googledrive"
-# TODO: encryption
-kvstore = KVStore(_name)
+
+kvstore = KVStub()
+
 
 # FIXME: There is several problems with this:
 # - does not use the common oauthtool

--- a/src/storage/imgur.py
+++ b/src/storage/imgur.py
@@ -5,11 +5,10 @@ from imgurpython.helpers.error import ImgurClientError
 
 from tools.config import CONFIG
 from tools.oauthtool import implicit_flow
-from tools.persistence import KVStore
+from tools.persistence import KVStub
 
 _name = "imgur"
-# TODO: encryption
-kvstore = KVStore(_name)
+kvstore = KVStub()
 
 
 def upload(file: str) -> str:

--- a/src/storage/sftp.py
+++ b/src/storage/sftp.py
@@ -5,11 +5,10 @@ import sys
 import paramiko
 
 from tools.config import CONFIG
-from tools.persistence import KVStore
+from tools.persistence import KVStub
 
 _name = "sftp"
-# TODO: encryption
-kvstore = KVStore(_name)
+kvstore = KVStub()
 
 # Load SFTP server info from config file
 HOSTNAME = CONFIG.get(_name, "hostname")
@@ -72,12 +71,12 @@ def _connect():
     # Start SSH session based on authentication type
     try:
         if AUTHENTICATION_TYPE == "password":
-            # FIXME: Use encrypted KVStore for password
+            # FIXME: Use KVStore instance for password
             password = CONFIG.get(_name, "password")
             transport.connect(username=USERNAME, password=password)
 
         elif AUTHENTICATION_TYPE == "key":
-            # FIXME: Use encrypted KVStore for password
+            # FIXME: Use KVStore instance for password
             key_filepath = CONFIG.get(_name, "key_filepath")
             key_passphrase = CONFIG.get(_name, "key_passphrase")
             private_key = paramiko.RSAKey.from_private_key_file(key_filepath, key_passphrase)

--- a/src/tools/persistence.py
+++ b/src/tools/persistence.py
@@ -8,66 +8,61 @@ import tools.encryption as crypt
 persistent_data_dir = "data/"
 
 
+class PersistentDataEncryptedError(BaseException):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+
 class KVStore(dict):
 
-    def __init__(self, module_name="general", pw=None):
+    def __init__(self, module_name=".general", pw=None, unlock=False):
+
+        if unlock and not pw:
+            raise ValueError("you have to supply a password to unlock the stored data")
+
         super().__init__()
+
         # TODO: this is user data - put this where it belongs
         os.makedirs(persistent_data_dir, exist_ok=True)
         self._filepath = persistent_data_dir + module_name
-        self._encrypted = pw is not None
-
-        if self._encrypted:
-            self._key = crypt.SymmetricKey(pw)
+        self._encrypt_on_write = pw is not None and unlock is False
+        self._key = crypt.SymmetricKey(pw) if pw else None
 
         # try to load persistent data
-        data = {}
-        dirty = False
-
-        # data read by pickle has to be a dict, just to make sure
-        def validate(x):
-            if not isinstance(x, dict):
-                raise TypeError("The data read from disk has to be a dict.")
-            return x
-
         try:
             with open(self._filepath, mode="rb") as file:
                 binary_data = file.read()
+        except IOError:
+            # there was no usable data, which is okay
+            return
 
-            if self._encrypted:
-                try:
-                    # decrypt binary data and deserialize
-                    data = validate(pickle.loads(self._key.decrypt(binary_data)))
-                except crypt.CryptoError:
-                    # data was not encrypted yet
-                    data = pickle.loads(binary_data)
-                    dirty = True
-            else:
-                # deserialize binary data
-                try:
-                    data = pickle.loads(binary_data)
-                except:
-                    # except is intentionally broad: pickle throws a variety of exceptions.
-                    # Data was probably encrypted, if not, we will catch the error later again.
-                    # TODO ask user for password instead of overwriting data
-                    logging.error("Trying to load encrypted data without decryption key.")
-                    dirty = True
-        except:
-            # except is intentionally broad:
-            # If anything happens, we can only overwrite the old data.
-            # There is no data yet, or the data has been corrupted.
-            pass
-        else:
-            self.update(data)
-            if dirty:
+        # there is data, load into dict
+        if pw:
+            try:
+                # decrypt, deserialize, update self
+                self.update(pickle.loads(self._key.decrypt(binary_data)))
+                # sync if the data is to be unlocked
+                if unlock:
+                    self.sync()
+            except crypt.CryptoError:
+                # data was not encrypted yet, load and sync back
+                self.update(pickle.loads(binary_data))
                 self.sync()
+        else:
+            try:
+                # deserialize, update self
+                self.update(pickle.loads(binary_data))
+            except:
+                # intentionally broad: pickle throws a variety of exceptions.
+                # data was probably encrypted, let caller handle this
+                raise PersistentDataEncryptedError
 
     def sync(self):
         data = {}
         data.update(self)
         bdata = pickle.dumps(data)
         with open(self._filepath, mode="wb") as file:
-            if self._encrypted:
+            if self._encrypt_on_write:
                 file.write(self._key.encrypt(bdata))
             else:
                 file.write(bdata)

--- a/src/tools/persistence.py
+++ b/src/tools/persistence.py
@@ -91,3 +91,14 @@ class KVStore(dict):
                 file.write(self._key.encrypt(bdata))
             else:
                 file.write(bdata)
+
+
+class KVStub(KVStore):
+
+    def __init__(self, *args, **kwargs):
+        # don't actually do anything
+        pass
+
+    def __getattr__(self, item):
+        # overwrite any calls to this object
+        raise NotImplementedError

--- a/src/tools/persistence.py
+++ b/src/tools/persistence.py
@@ -1,4 +1,3 @@
-import logging
 import pickle
 import os
 
@@ -14,28 +13,42 @@ class PersistentDataEncryptedError(BaseException):
 
 
 class KVStore(dict):
+    """
+    An extended dictionary that is similar to Python's "shelve", but optionally
+    supports encryption. Also supports transitions between encrypted and
+    unencrypted modes.
+    """
 
     def __init__(self, module_name=".general", pw=None, unlock=False):
         """
-        Initialize a KVStore instance.
+        Initialize a KVStore instance. Supply a password to encrypt the data
+        on disk. If you set unlock to True, you can decrypt previously
+        encrypted data.
 
         :param module_name:
-        Determines which dictionary to use. Will look for a file with that name.
+        Determines which dictionary to use. Will look for a file with that name
+        in the persistent data directory.
 
         :param pw:
-        Password for decrypting or encrypting the persistent data
+        Password for decrypting or encrypting the persistent data. If None,
+        will not encrypt the data on disk. Has to be specified for decryption
+        when unlock == True.
 
         :param unlock:
-        If True, will encrypt persistent data using pw, but write back unencrypted
+        If True, will decrypt existing persistent data using specified pw and
+        write unencrypted data back to disk immediately.
 
         :raises ValueError:
-        When unlock is set to True, but no password is supplied.
+        When unlock is set to True, but no password is supplied. The password
+        is needed for decryption.
 
         :raises crypt.CryptoError:
         When the supplied password is wrong.
 
         :raises PersistentDataEncryptedError:
-        When encryption was turned off by the user since the last run and the data is still encrypted.
+        When encryption was turned off by the user since the last run and the
+        data is still encrypted. In this case, you should specify a pw and set
+        unlock to True. This will decrypt the data on disk.
         """
 
         if unlock and not pw:


### PR DESCRIPTION
This only covers one part of #22: The 'keyring' encryption type asks the user to create an encryption password, which will be stored in the system keyring. At runtime, this password will be read and used to decrypt the persistent data.

The commit messages are very thorough, so most of the changes are documented there.
Regarding the TODOs in commit 4a92486:
- 'password' encryption will be addressed later, when the GUI is done. It should not have any influence on this pull request.
- I will test this on windows and report back soon.
- `_load_persistent_data()` will be refactored once we get a system with "generic program flows" set up, as discussed in #34 
- refactoring the storage providers:  bca2ff3 provides a solution for now, I think this will be refactored anyway when we adjust the storage providers to work for the requirements in #34.

So after testing (and maybe fixing) Windows, this should be ready to go. Please go ahead and review!
