### PR TITLE
Standardize the storage providers

### DIFF
--- a/src/res/instantshare.default
+++ b/src/res/instantshare.default
@@ -44,9 +44,7 @@ user_id = 0
 access_token = 0
 
 [googledrive]
-app_key = 0
-auth_url = 0
-scope = 0
+app_key = 101202535039-nnofrifa409n8psoc9sv6bcb434c44f3.apps.googleusercontent.com
 
 [owncloud]
 url = 0

--- a/src/res/instantshare.default
+++ b/src/res/instantshare.default
@@ -50,7 +50,8 @@ hostname = example.com
 # Base directory for files (. is home directory of user)
 base_dir = .
 port = 22
-authentication_type = password OR key
+# Possible Values: password, key
+authentication_type = password
 # Authentication type key
 key_filepath = 0
 

--- a/src/res/instantshare.default
+++ b/src/res/instantshare.default
@@ -38,10 +38,6 @@ screenshot_whole = Lcontrol+Lshift+3
 
 [dropbox]
 app_key = 81glnb2w8xfo0lz
-auth_url = 0
-scope = 0
-user_id = 0
-access_token = 0
 
 [googledrive]
 app_key = 101202535039-nnofrifa409n8psoc9sv6bcb434c44f3.apps.googleusercontent.com

--- a/src/res/instantshare.default
+++ b/src/res/instantshare.default
@@ -40,7 +40,7 @@ screenshot_whole = Lcontrol+Lshift+3
 app_key = 81glnb2w8xfo0lz
 
 [googledrive]
-app_key = 101202535039-nnofrifa409n8psoc9sv6bcb434c44f3.apps.googleusercontent.com
+app_key = 774886165931-ks0ntcb32p1mhi0nnv8tcmob81e0oetj.apps.googleusercontent.com
 
 [owncloud]
 url = 0

--- a/src/res/instantshare.default
+++ b/src/res/instantshare.default
@@ -58,12 +58,8 @@ hostname = example.com
 # Base directory for files (. is home directory of user)
 base_dir = .
 port = 22
-username = 0
 authentication_type = password OR key
-# Authentication type password
-password = 0
 # Authentication type key
-key_passphrase = 0
 key_filepath = 0
 
 [imgur]

--- a/src/res/instantshare.default
+++ b/src/res/instantshare.default
@@ -50,8 +50,6 @@ scope = 0
 
 [owncloud]
 url = 0
-username = 0
-password = 0
 
 [sftp]
 hostname = example.com

--- a/src/storage/googledrive.py
+++ b/src/storage/googledrive.py
@@ -11,9 +11,8 @@ from tools.config import CONFIG
 from tools.oauthtool import implicit_flow
 from tools.persistence import KVStub
 
+AUTHORIZATION_ENDPOINT = "https://accounts.google.com/o/oauth2/v2/auth"
 SCOPES = 'https://www.googleapis.com/auth/drive'
-CLIENT_SECRET_FILE = 'client_secret.json'
-APPLICATION_NAME = 'Instantshare'
 _name = "googledrive"
 
 kvstore = KVStub()
@@ -86,11 +85,10 @@ def upload(file: str) -> str:
 
 
 def _authorize():
-    authorization_endpoint = "https://accounts.google.com/o/oauth2/v2/auth"
     app_key = CONFIG.get(_name, "app_key")
 
     # Start OAuth2 implicit flow
-    auth_response = implicit_flow(authorization_endpoint, app_key, scope=[SCOPES])
+    auth_response = implicit_flow(AUTHORIZATION_ENDPOINT, app_key, scope=[SCOPES])
 
     # Check if authorization was successful
     if "error" in auth_response and auth_response["error"] is not None:

--- a/src/storage/sftp.py
+++ b/src/storage/sftp.py
@@ -70,10 +70,16 @@ def _connect():
     kvstore_dirty = False
 
     # initial case: no username or password present
-    if "username" not in kvstore.keys() or "password" not in kvstore.keys() or "key passphrase" not in kvstore.keys():
-        prompt = "password" if AUTHENTICATION_TYPE == "password" else "key passphrase"
-        kvstore["username"], kvstore[prompt] = _get_credentials(prompt)
-        kvstore_dirty = True
+    if AUTHENTICATION_TYPE == "password":
+        if "username" not in kvstore.keys() or "password" not in kvstore.keys():
+            kvstore["username"], kvstore["password"] = _get_credentials("password")
+            kvstore_dirty = True
+    elif AUTHENTICATION_TYPE == "key":
+        if "username" not in kvstore.keys() or "key passphrase" not in kvstore.keys():
+            kvstore["username"], kvstore["key passphrase"] = _get_credentials("key passphrase")
+            kvstore_dirty = True
+    else:
+        logging.error("Unknown authentication type")
 
     while True:
         try:
@@ -97,6 +103,7 @@ def _connect():
         kvstore.sync()
 
     return transport, paramiko.SFTPClient.from_transport(transport)
+
 
 def _get_credentials(prompt):
     from gui.dialogs import text_input


### PR DESCRIPTION
I mostly standardized the storage providers to use the KVStore for encrypted storage where possible and our OAuth implicit flow implementation for authentication with Google Drive.
I am currently using the app key related to my private Google account for Google Drive, we should update this to the organizations account app key before merging.

ToDo:

- [x] update app key of Google Drive in the configuration