### PR TITLE
Alternative screenshot tool using Snipping Tool

### DIFF
--- a/src/res/instantshare.default
+++ b/src/res/instantshare.default
@@ -20,7 +20,7 @@ storage = imgur
 screenshot_dir = Screenshots
 
 # The screenshot tool to use. The name corresponds to the name of the python modules in the screenshot package.
-# Possible Values: windows_tk (Windows only), gnome_screenshot (Linux only)
+# Possible Values: windows_tk (Windows only), snippingtool (Windows 10 Creators Update only), gnome_screenshot (Linux only)
 screenshot_tool = $SCREENSHOT_TOOL
 
 # Whether or not to automatically copy the public URL to the uploaded medium to the clipboard.

--- a/src/screenshot/snippingtool.py
+++ b/src/screenshot/snippingtool.py
@@ -1,0 +1,16 @@
+from subprocess import call
+from PIL import ImageGrab
+from libraries.pyrobot import Robot
+
+_r = Robot()
+
+
+def take_screenshot_whole(path):
+    image = _r.take_screenshot()
+    image.save(path, "PNG")
+
+
+def take_screenshot_crop(path):
+    call(["snippingtool", "/clip"])
+    image = ImageGrab.grabclipboard()
+    image.save(path, "png")

--- a/src/screenshot/snippingtool.py
+++ b/src/screenshot/snippingtool.py
@@ -13,5 +13,5 @@ def take_screenshot_whole(path):
 def take_screenshot_crop(path):
     call(["snippingtool", "/clip"])
     image = ImageGrab.grabclipboard()
-    if image != None:
+    if image is not None:
         image.save(path, "png")

--- a/src/screenshot/snippingtool.py
+++ b/src/screenshot/snippingtool.py
@@ -7,7 +7,7 @@ _r = Robot()
 
 def take_screenshot_whole(path):
     image = _r.take_screenshot()
-    image.save(path, "PNG")
+    image.save(path, "png")
 
 
 def take_screenshot_crop(path):

--- a/src/screenshot/snippingtool.py
+++ b/src/screenshot/snippingtool.py
@@ -13,4 +13,5 @@ def take_screenshot_whole(path):
 def take_screenshot_crop(path):
     call(["snippingtool", "/clip"])
     image = ImageGrab.grabclipboard()
-    image.save(path, "png")
+    if image != None:
+        image.save(path, "png")


### PR DESCRIPTION
Since the Windows Creators Update you can call the Snipping Tool with the parameter "/clip" from the command line.

Issues with this implementation:
- Snipping Tool always defaults to the last capture mode used, there is no way to configure the capture mode via command line parameters. This is why we still have to use our pyrobot library to capture the whole screen.

For more information, see here: http://www.winhelponline.com/blog/capture-screen-region-snippingtool-clip-shortcut-windows-10/