### PR TITLE
Toast notifications

### DIFF
--- a/requirements-windows.txt
+++ b/requirements-windows.txt
@@ -1,4 +1,3 @@
 -r requirements.txt
 pypiwin32
 pyhooked
-win10toast

--- a/requirements-windows.txt
+++ b/requirements-windows.txt
@@ -1,3 +1,4 @@
 -r requirements.txt
 pypiwin32
 pyhooked
+win10toast

--- a/src/res/instantshare.default
+++ b/src/res/instantshare.default
@@ -44,6 +44,10 @@ cb_autocopy = True
 # Possible Values: True, False
 notification_sound = True
 
+# Whether or not to show a notification toast when the upload is done.
+# Possible Values: True, False
+notification_toast = False
+
 [hotkeys]
 screenshot_crop = Lcontrol+Lshift+2
 screenshot_whole = Lcontrol+Lshift+3

--- a/src/res/instantshare.default
+++ b/src/res/instantshare.default
@@ -44,7 +44,7 @@ cb_autocopy = True
 # Possible Values: True, False
 notification_sound = True
 
-# Whether or not to show a notification toast when the upload is done.
+# Whether or not to show a notification text when the upload is done.
 # Possible Values: True, False
 notification_toast = False
 

--- a/src/storage/__init__.py
+++ b/src/storage/__init__.py
@@ -1,6 +1,5 @@
-import logging
-
 import getpass
+import logging
 from importlib import import_module
 
 import keyring
@@ -69,8 +68,8 @@ def _load_persistent_data(module: str):
             return KVStore(module)
         except PersistentDataEncryptedError:
             pw = text_input("Encryption Password",
-                              "Please enter your previous encryption password (one last time):",
-                              hidden=True)
+                            "Please enter your previous encryption password (one last time):",
+                            hidden=True)
             while True:
                 try:
                     kvs = KVStore(module, pw, unlock=True)
@@ -99,6 +98,7 @@ def _hoster_for(media_type: str):
 
 def _upload(hoster, path):
     play_sounds = CONFIG.getboolean(CONFIG.general, "notification_sound")
+    show_notifications = CONFIG.getboolean(CONFIG.general, "notification_toast")
 
     # upload to storage
     try:
@@ -109,6 +109,10 @@ def _upload(hoster, path):
         if play_sounds:
             import tools.audio as a
             a.play_wave_file(dirs.res + "/error.wav")
+        if show_notifications:
+            from tools.toast import Toast
+            t = Toast()
+            t.show("Error", "Failed to upload media.")
         return
     logging.info("Uploaded file to: " + url)
 
@@ -124,3 +128,7 @@ def _upload(hoster, path):
     if play_sounds:
         import tools.audio as a
         a.play_wave_file(dirs.res + "/notification.wav")
+    if show_notifications:
+        from tools.toast import Toast
+        t = Toast()
+        t.show("Upload Finished", "Media upload was successful.")

--- a/src/tools/audio.py
+++ b/src/tools/audio.py
@@ -1,11 +1,12 @@
 import pyaudio
 import wave
+import threading
 
 # define the amount of data to be read at once from the wave file
 _buffer_size = 1024
 
 
-def play_wave_file(path):
+def _play_wave_file(path):
     # open the wave file
     wf = wave.open(path, 'rb')
 
@@ -30,3 +31,8 @@ def play_wave_file(path):
     stream.stop_stream()
     stream.close()
     p.terminate()
+
+
+def play_wave_file(path):
+    play_thread = threading.Thread(target=_play_wave_file, args=(path,))
+    play_thread.start()

--- a/src/tools/toast.py
+++ b/src/tools/toast.py
@@ -1,0 +1,21 @@
+from tools.toolbox import Platform
+
+
+class Toast(Platform):
+    def __init__(self):
+        self.show = lambda title, message, icon, timeout: None
+        super().__init__()
+
+    def init_linux(self):
+        pass
+
+    def init_windows(self):
+        def s(title, message, icon=None, timeout=0):
+            from win10toast import ToastNotifier
+            toaster = ToastNotifier()
+            toaster.show_toast(title, message, icon, timeout)
+
+        self.show = s
+
+    def init_osx(self):
+        pass

--- a/src/tools/toast.py
+++ b/src/tools/toast.py
@@ -1,3 +1,4 @@
+from tools import dirs
 from tools.toolbox import Platform
 
 
@@ -7,7 +8,7 @@ class Toast(Platform):
         super().__init__()
 
     def init_linux(self):
-        def show(title, message, icon=None, timeout=0):
+        def show(title, message, icon=dirs.res + "/instantshare.ico", timeout=0):
             from subprocess import Popen, PIPE
             import shlex
             cmd = shlex.split(
@@ -23,7 +24,7 @@ class Toast(Platform):
         self.show = show
 
     def init_windows(self):
-        def s(title, message, icon=None, timeout=0):
+        def s(title, message, icon=dirs.res + "/instantshare.ico", timeout=0):
             from win10toast import ToastNotifier
             toaster = ToastNotifier()
             toaster.show_toast(title, message, icon, timeout)

--- a/src/tools/toast.py
+++ b/src/tools/toast.py
@@ -7,7 +7,20 @@ class Toast(Platform):
         super().__init__()
 
     def init_linux(self):
-        pass
+        def show(title, message, icon=None, timeout=0):
+            from subprocess import Popen, PIPE
+            import shlex
+            cmd = shlex.split(
+                "notify-send --icon={icon} --expire-time={timeout} \"{title}\" \"{message}\"".format(
+                    icon=str(icon),
+                    timeout=str(timeout * 1000),
+                    title=title,
+                    message=message
+                )
+            )
+            Popen(cmd).communicate()
+
+        self.show = show
 
     def init_windows(self):
         def s(title, message, icon=None, timeout=0):


### PR DESCRIPTION
Progress for Issue #3 
Seems to not only work fine on Windows 10, but also on older versions like Windows 7.

The used library [Windows-10-Toast-Notifications](https://github.com/jithurjacob/Windows-10-Toast-Notifications) is not installable via pip for Python versions above 3.3 at the moment.(At least not via the requirements.txt) I have created a [pull request](https://github.com/jithurjacob/Windows-10-Toast-Notifications/pull/12) and we should wait until that is merged and the package is updated in the PyPi repository before merging this PR.

If you want to test the functionality right now, install the dependencies manually like this:
```
pip install pypiwin32
pip install win10toast --no-dependencies
```

Edit by @dtext:
Closes #3. We could merge this now, the feature is not usable in windows unless you install the dependencies manually as described above. The PR has been merged now, it's just a matter of time until pypi gets updated.