### PR TITLE
Text sharing

### DIFF
--- a/src/cli/text.py
+++ b/src/cli/text.py
@@ -1,7 +1,39 @@
 """
-Not implemented yet.
+Upload text from the clipboard or from stdin and share its public URL.
+
+Usage: instantshare text [options]
+
+Options:
+  -h, --help            Print this information
+  --stdin               Receive text from stdin instead of the clipboard
+  --storage=<provider>  Overwrite the storage config parameter
 """
+from docopt import docopt
+
+import storage
+from tools import dirs
 
 
 def main(argv):
-    print(__doc__)
+    args = docopt(__doc__, argv)
+
+    # read data from clipboard or stdin
+    if args["--stdin"]:
+        import sys
+        data = sys.stdin.read()
+    else:
+        from tools.clipboard import Clipboard
+        c = Clipboard()
+        data = c.get()
+
+    # save to file
+    file_path = dirs.build_filename(dirs.MediaTypes.TEXT)
+    with open(file_path, "w") as text_file:
+        text_file.writelines(data)
+
+    # upload
+    hoster = args["--storage"]
+    if hoster:
+        storage.upload_to(hoster, file_path)
+    else:
+        storage.upload_text(file_path)

--- a/src/res/instantshare.default
+++ b/src/res/instantshare.default
@@ -21,12 +21,14 @@ encryption = keyring
 # googledrive            y        y     y     y     y
 # sftp                   y        y     y     y     y
 # owncloud               y        y     y     y     y
+# twitter_intent         n        n     n     n     y
+# pastebin               n        n     n     n     y
 #
 storage_screenshots = imgur
 storage_files = dropbox
 storage_audio = dropbox
 storage_videos =
-storage_text =
+storage_text = pastebin
 
 # The base directory name for screenshots when using hosters like dropbox
 screenshot_dir = Screenshots
@@ -69,3 +71,6 @@ key_filepath = 0
 
 [imgur]
 client_id = a5e814c239e21f0
+
+[pastebin]
+app_key = adddc74baf0cd6344fdc1f20f47355b0

--- a/src/storage/__init__.py
+++ b/src/storage/__init__.py
@@ -16,12 +16,8 @@ def upload_generic_file(path: str):
     _upload(_hoster_for("files"), path)
 
 
-def upload_text(text: str):
-    # TODO come up with a strategy to make this elegant
-    # some storage options want a path
-    # text only hosters like pastebin probably only need a string -> always make a file in tempdir?
-    # Syntax Highlighting for pastebin? -> should be handled by pastebin.py
-    pass
+def upload_text(path: str):
+    _upload(_hoster_for("text"), path)
 
 
 def upload_audio(path: str):

--- a/src/storage/__init__.py
+++ b/src/storage/__init__.py
@@ -100,8 +100,9 @@ def _upload(hoster, path):
     try:
         url = hoster.upload(path)
         if url is None:
-            raise RuntimeError
-    except:
+            raise Exception
+    except Exception as e:
+        logging.error("Error occured while uploading file to hoster:\n" + e)
         if play_sounds:
             import tools.audio as a
             a.play_wave_file(dirs.res + "/error.wav")

--- a/src/storage/pastebin.py
+++ b/src/storage/pastebin.py
@@ -1,0 +1,17 @@
+from urllib import request, parse
+
+from tools.config import CONFIG
+
+_name = "pastebin"
+
+
+def upload(file: str) -> str:
+    data = {
+        "api_dev_key": CONFIG.get(_name, "app_key"),
+        "api_option": "paste",
+        "api_paste_code": open(file, "r").read()
+    }
+    post_data = parse.urlencode(data).encode("ascii")
+    response = request.urlopen("https://pastebin.com/api/api_post.php", post_data)
+    public_url = str(response.read(), encoding="ascii")
+    return public_url

--- a/src/storage/twitter_intent.py
+++ b/src/storage/twitter_intent.py
@@ -1,0 +1,10 @@
+import threading
+import webbrowser
+from urllib.parse import quote
+
+
+def upload(file: str) -> str:
+    data = open(file, "r").read()
+    url = "https://twitter.com/intent/tweet?text=" + quote(data, safe="")
+    threading.Thread(target=lambda: webbrowser.open(url)).start()
+    return data


### PR DESCRIPTION
Not much to say here, really. I implemented uploading text from clipboard or stdin to hosters like Dropbox and OwnCloud. I also added 2 new ones: `twitter_intent` uses twitters intent api to make a tweet.`pastebin` creates a new paste and returns the public url of the paste.

A more elaborate description can be found in the commit messages.

Pastebin also supports syntax highlighting, but that is an option we could look into later, just to keep this PR compact for now. I also think that's beyond the scope of the feature im creating this PR for.

Closes #10.