### PR TITLE
PyInstaller specification file for building the application into an executable file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,6 @@ var/
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
 *.manifest
-*.spec
 
 # Installer logs
 pip-log.txt

--- a/README.rst
+++ b/README.rst
@@ -47,9 +47,28 @@ Linux
 
     $ pip install -r requirements-linux.txt
 
+Optional: Build an executable file
+----------------------------------
+We use PyInstaller for building the app into an executable file. We already provide a PyInstaller specification file, so building comes down to the following steps:
+
+- Install PyInstaller using pip
+
+.. code-block:: bash
+
+    $ pip install PyInstaller
+
+- Run PyInstaller with the provided specification file in project root directory
+
+.. code-block:: bash
+
+    $ pyinstaller instantshare.spec
+
+PyInstaller creates a build directory containing temporary files and a dist directory containing the executable application.
+
 Run the app
 ===========
-If you installed all the dependencies correctly, running the app should be as simple as typing:
+If you build the app beforehand, running the app is as simple as running the executable file in the new `dist` folder.
+If you skipped the optional build, you can still run the app like this:
 
 ::
 

--- a/instantshare.spec
+++ b/instantshare.spec
@@ -21,8 +21,7 @@ hidden_imports = ['cli.audio',
 
 added_files = [('src/res', 'res')]
 
-a = Analysis(['src\\instantshare'],
-             pathex=['C:\\Developer\\instantshare'],
+a = Analysis(['src/instantshare'],
              binaries=[],
              datas=added_files,
              hiddenimports=hidden_imports,

--- a/instantshare.spec
+++ b/instantshare.spec
@@ -1,0 +1,51 @@
+# -*- mode: python -*-
+
+block_cipher = None
+
+hidden_imports = ['cli.audio', 
+                  'cli.file', 
+                  'cli.gui', 
+                  'cli.screen', 
+                  'cli.text', 
+                  'cli.video',
+                  'screenshot.snippingtool',
+                  'screenshot.windows_tk',
+                  'screenshot.gnome_screenshot',
+                  'storage.dropbox',
+                  'storage.googledrive',
+                  'storage.imgur',
+                  'storage.owncloud',
+                  'storage.pastebin',
+                  'storage.sftp',
+                  'storage.twitter_intent']
+
+added_files = [('src/res', 'res')]
+
+a = Analysis(['src\\instantshare'],
+             pathex=['C:\\Developer\\instantshare'],
+             binaries=[],
+             datas=added_files,
+             hiddenimports=hidden_imports,
+             hookspath=[],
+             runtime_hooks=[],
+             excludes=[],
+             win_no_prefer_redirects=False,
+             win_private_assemblies=False,
+             cipher=block_cipher)
+pyz = PYZ(a.pure, a.zipped_data,
+             cipher=block_cipher)
+exe = EXE(pyz,
+          a.scripts,
+          exclude_binaries=True,
+          name='instantshare',
+          debug=False,
+          strip=False,
+          upx=True,
+          console=False )
+coll = COLLECT(exe,
+               a.binaries,
+               a.zipfiles,
+               a.datas,
+               strip=False,
+               upx=True,
+               name='instantshare')


### PR DESCRIPTION
This PR adds a specification file for PyInstaller that enables us to build instantshare into an executable file that doesn't require a python runtime. We can use this to ship prebuilt releases for end users in the near future.

To build the app:
- Install PyInstaller using pip
- Execute `pyinstaller instantshare.spec` in project root directory

This creates a temporary `build` folder and a `dist` folder, the latter contains the executable file among others. 

PyInstaller also comes with the option to build the entire dist folder output into **only one** executable file but this comes with a big drawback: Every time that file is executed, it creates a temporary folder in the temp-folder location of the running OS.

The one executable file contains an embedded archive of all the Python modules used by the script, as well as compressed copies of any non-Python support files. At every launch, the support files are uncompressed and copied into the temporary folder. This process takes time and after testing this, that additional time at each startup is not worth the result.

For Windows, we should consider creating an installer that installs the built app into %PROGRAMFILES%/instantshare and optionally creates start menu shortcuts and entries for autostarting the application in GUI mode.

I've tested the PyInstaller build on Windows 10 x64 1703, a test on any linux based OS would be appreciated.

This PR is the first step for #12.
