### PR TITLE
URL Shortener Support

### DIFF
--- a/src/res/instantshare.default
+++ b/src/res/instantshare.default
@@ -37,6 +37,11 @@ screenshot_dir = Screenshots
 # Possible Values: windows_tk (Windows only), snippingtool (Windows 10 Creators Update only), gnome_screenshot (Linux only)
 screenshot_tool = $SCREENSHOT_TOOL
 
+# How (or if at all) to shorten obtained public URLs to the uploaded medium.
+# Possible Values: tinyurl
+# Any other setting will lead to URLs not being shortened.
+url_shortener = None
+
 # Whether or not to automatically copy the public URL to the uploaded medium to the clipboard.
 # When not copied to the clipboard, the URL will be opened in the web browser.
 # Possible Values: True, False

--- a/src/storage/__init__.py
+++ b/src/storage/__init__.py
@@ -9,6 +9,7 @@ from tools import dirs
 from tools.config import config, general
 from tools.encryption import CryptoError
 from tools.persistence import KVStore, PersistentDataEncryptedError
+from tools.shorturl import get_url_shortener
 
 
 def upload_generic_file(path: str):
@@ -112,6 +113,10 @@ def _upload(hoster, path):
             t.show("Error", "Failed to upload media.")
         return
     logging.info("Uploaded file to: " + url)
+
+    # shorten URL as defined in config
+    url_shortener = get_url_shortener(config[general]["url_shortener"])
+    url = url_shortener.shorten(url)
 
     # execute user defined action
     if config[general]["cb_autocopy"]:

--- a/src/tools/shorturl.py
+++ b/src/tools/shorturl.py
@@ -1,3 +1,4 @@
+import logging
 from abc import abstractmethod, ABCMeta
 from urllib import request
 
@@ -6,6 +7,9 @@ class UrlShortener(metaclass=ABCMeta):
     @abstractmethod
     def shorten(self, url: str) -> str:
         pass
+
+    def log(self, url):
+        logging.info("Short URL: {}".format(url))
 
 
 class Off(UrlShortener):
@@ -16,7 +20,9 @@ class Off(UrlShortener):
 class TinyURL(UrlShortener):
     def shorten(self, url: str) -> str:
         response = request.urlopen("http://tinyurl.com/api-create.php?url={}".format(url))
-        return str(response.read(), encoding="ascii")
+        url = str(response.read(), encoding="ascii")
+        self.log(url)
+        return url
 
 
 def get_url_shortener(name: str) -> UrlShortener:

--- a/src/tools/shorturl.py
+++ b/src/tools/shorturl.py
@@ -1,0 +1,25 @@
+from abc import abstractmethod, ABCMeta
+from urllib import request
+
+
+class UrlShortener(metaclass=ABCMeta):
+    @abstractmethod
+    def shorten(self, url: str) -> str:
+        pass
+
+
+class Off(UrlShortener):
+    def shorten(self, url: str):
+        return url
+
+
+class TinyURL(UrlShortener):
+    def shorten(self, url: str) -> str:
+        response = request.urlopen("http://tinyurl.com/api-create.php?url={}".format(url))
+        return str(response.read(), encoding="ascii")
+
+
+def get_url_shortener(name: str) -> UrlShortener:
+    if name == "tinyurl":
+        return TinyURL()
+    return Off()


### PR DESCRIPTION
Closes #52. When testing, add `url_shortener = tinyurl` to the configuration.
For now, no dynamic loading of modules involved. Let's see if we ever need that.